### PR TITLE
feat: add Nakamoto metrics, effective APR, and per-context chain config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,15 @@
+# Chain target is chosen at build time (see src/chain-config.ts) and switched
+# per Netlify deploy context. Production builds target mainnet; deploy previews
+# (pull requests) and branch deploys target the testnet.
+[context.production.environment]
+  VITE_CHAIN_ENV = "mainnet"
+
+[context.deploy-preview.environment]
+  VITE_CHAIN_ENV = "testnet"
+
+[context.branch-deploy.environment]
+  VITE_CHAIN_ENV = "testnet"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"
@@ -10,7 +22,10 @@
   https://staking.atom.one,
   '''
   Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-  Content-Security-Policy = "default-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; img-src 'self' data: https:; connect-src https://atomone-rpc.allinbits.com https://atomone-api.allinbits.com"
+  # Content-Security-Policy is intentionally NOT set here. Its connect-src must
+  # differ per deploy context (mainnet vs testnet endpoints), but netlify.toml
+  # headers apply to every context. It is emitted into a "_headers" file at build
+  # time instead — see the netlify-csp-headers plugin in vite.config.ts.
   X-Frame-Options = "SAMEORIGIN"
   X-Content-Type-Options = "nosniff"
   Referrer-Policy = "strict-origin"

--- a/src/chain-config.testnet.json
+++ b/src/chain-config.testnet.json
@@ -1,0 +1,46 @@
+{
+  "rpc": "https://atomone-testnet-1-rpc.allinbits.services/",
+  "rest": "https://atomone-testnet-1-api.allinbits.services/",
+  "chainId": "atomone-testnet-1",
+  "chainName": "AtomOne Testnet",
+  "bip44": {
+    "coinType": 118
+  },
+  "bech32Config": {
+    "bech32PrefixAccAddr": "atone",
+    "bech32PrefixAccPub": "atonepub",
+    "bech32PrefixValAddr": "atonevaloper",
+    "bech32PrefixValPub": "atonevaloperpub",
+    "bech32PrefixConsAddr": "atonevalcons",
+    "bech32PrefixConsPub": "atonevalconspub"
+  },
+  "currencies": [
+    {
+      "coinDenom": "ATONE",
+      "coinMinimalDenom": "uatone",
+      "coinDecimals": 6
+    },
+    {
+      "coinDenom": "PHOTON",
+      "coinMinimalDenom": "uphoton",
+      "coinDecimals": 6
+    }
+  ],
+  "stakeCurrency": {
+    "coinDenom": "ATONE",
+    "coinMinimalDenom": "uatone",
+    "coinDecimals": 6
+  },
+  "feeCurrencies": [
+    {
+      "coinDenom": "ATONE",
+      "coinMinimalDenom": "uatone",
+      "coinDecimals": 6
+    },
+    {
+      "coinDenom": "PHOTON",
+      "coinMinimalDenom": "uphoton",
+      "coinDecimals": 6
+    }
+  ]
+}

--- a/src/chain-config.ts
+++ b/src/chain-config.ts
@@ -1,0 +1,17 @@
+import mainnet from "./chain-config.json";
+import testnet from "./chain-config.testnet.json";
+
+/*
+ * Selects which chain the dapp targets at build time. VITE_CHAIN_ENV is set per
+ * Netlify deploy context in netlify.toml: "testnet" for deploy previews and
+ * branch deploys, "mainnet" for production. Anything other than "testnet" —
+ * including local development where the variable is unset — falls back to
+ * mainnet. The selected object is the full chain config handed to wallets
+ * (Keplr/Leap/Cosmostation suggestChain), so each environment must be complete.
+ */
+const chainConfig: typeof mainnet =
+  import.meta.env.VITE_CHAIN_ENV === "testnet"
+    ? testnet
+    : mainnet;
+
+export default chainConfig;

--- a/src/components/helper/UserBalance.vue
+++ b/src/components/helper/UserBalance.vue
@@ -2,7 +2,7 @@
 import { useQuery } from "@tanstack/vue-query";
 import { computed, Ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import { useWallet } from "@/composables/useWallet";
 import { formatAmount } from "@/utility";
 

--- a/src/components/popups/Delegate.vue
+++ b/src/components/popups/Delegate.vue
@@ -6,7 +6,7 @@ import BigNumber from "bignumber.js";
 import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { computed, ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import ModalWrap from "@/components/common/ModalWrap.vue";
 import CommonButton from "@/components/ui/CommonButton.vue";
 import Icon from "@/components/ui/Icon.vue";

--- a/src/components/popups/Mint.vue
+++ b/src/components/popups/Mint.vue
@@ -6,7 +6,7 @@ import { useClipboard } from "@vueuse/core";
 import BigNumber from "bignumber.js";
 import { computed, ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import ModalWrap from "@/components/common/ModalWrap.vue";
 import CommonButton from "@/components/ui/CommonButton.vue";
 import Icon from "@/components/ui/Icon.vue";

--- a/src/components/popups/Redelegate.vue
+++ b/src/components/popups/Redelegate.vue
@@ -6,7 +6,7 @@ import BigNumber from "bignumber.js";
 import { MsgBeginRedelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { computed, ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import ModalWrap from "@/components/common/ModalWrap.vue";
 import CommonButton from "@/components/ui/CommonButton.vue";
 import Icon from "@/components/ui/Icon.vue";

--- a/src/components/popups/Undelegate.vue
+++ b/src/components/popups/Undelegate.vue
@@ -6,7 +6,7 @@ import BigNumber from "bignumber.js";
 import { MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { computed, ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import ModalWrap from "@/components/common/ModalWrap.vue";
 import CommonButton from "@/components/ui/CommonButton.vue";
 import Icon from "@/components/ui/Icon.vue";

--- a/src/components/popups/WalletConnect.vue
+++ b/src/components/popups/WalletConnect.vue
@@ -4,7 +4,7 @@ import { bech32 } from "bech32";
 import { computed, Ref, ref } from "vue";
 
 import { bus } from "@/bus";
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import UserBalance from "@/components//helper/UserBalance.vue";
 import ConnectButton from "@/components/ui/ConnectButton.vue";
 import { getWalletHelp, useWallet, Wallets } from "@/composables/useWallet";

--- a/src/composables/usePhoton.ts
+++ b/src/composables/usePhoton.ts
@@ -1,7 +1,7 @@
 import { MsgMintPhoton } from "@atomone/atomone-types/atomone/photon/v1/tx";
 import { EncodeObject } from "@cosmjs/proto-signing";
 
-import chainInfo from "@/chain-config.json";
+import chainInfo from "@/chain-config";
 import { useWallet } from "@/composables/useWallet";
 import CommandBuilder from "@/utility/commandBuilder.ts";
 

--- a/src/composables/useValidators.ts
+++ b/src/composables/useValidators.ts
@@ -2,7 +2,7 @@ import { EncodeObject } from "@cosmjs/proto-signing";
 import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 import { MsgBeginRedelegate, MsgDelegate, MsgUndelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 
-import chainInfo from "@/chain-config.json";
+import chainInfo from "@/chain-config";
 import { useWallet } from "@/composables/useWallet";
 import CommandBuilder from "@/utility/commandBuilder";
 

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -8,7 +8,7 @@ import { OfflineAminoSigner } from "@keplr-wallet/types";
 import { useQueryClient } from "@tanstack/vue-query";
 import { computed, nextTick, Ref, ref } from "vue";
 
-import chainInfo from "@/chain-config.json";
+import chainInfo from "@/chain-config";
 
 export enum Wallets {
   keplr = "Keplr",

--- a/src/utility/text.ts
+++ b/src/utility/text.ts
@@ -1,7 +1,7 @@
 import { Coin } from "@cosmjs/proto-signing";
 import BigNumber from "bignumber.js";
 
-import chainConfig from "../chain-config.json";
+import chainConfig from "../chain-config";
 
 export function capitalizeFirstLetter (text: string) {
   return text.charAt(0).toUpperCase() + text.slice(1);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,7 +3,7 @@ import { Coin } from "@cosmjs/proto-signing";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { computed, Ref } from "vue";
 
-import chainConfig from "@/chain-config.json";
+import chainConfig from "@/chain-config";
 import Claim from "@/components/popups/Claim.vue";
 import Delegate from "@/components/popups/Delegate.vue";
 import Redelegate from "@/components/popups/Redelegate.vue";
@@ -18,11 +18,162 @@ const queryClient = useQueryClient();
 const fetcher = () => fetch(chainConfig.rest + "cosmos/staking/v1beta1/validators?pagination.limit=1000").then((response) => response.json());
 const delegationsFetcher = (address: Ref<string>) => fetch(`${chainConfig.rest}cosmos/staking/v1beta1/delegations/${address.value}?pagination.limit=1000`).then((response) => response.json());
 const rewardsFetcher = (address: Ref<string>) => fetch(`${chainConfig.rest}cosmos/distribution/v1beta1/delegators/${address.value}/rewards?pagination.limit=1000`).then((response) => response.json());
+const nakamotoBonusCoefficientFetcher = () => fetch(chainConfig.rest + "cosmos/distribution/v1beta1/nakamoto_bonus_coefficient").then((response) => response.json());
+const annualProvisionsFetcher = () => fetch(chainConfig.rest + "cosmos/mint/v1beta1/annual_provisions").then((response) => response.json());
+const distributionParamsFetcher = () => fetch(chainConfig.rest + "cosmos/distribution/v1beta1/params").then((response) => response.json());
 const { data } = useQuery({
   queryKey: ["validators"],
   queryFn: () => fetcher(),
   placeholderData: keepPreviousData
 });
+const { data: nakamotoBonusCoefficientData } = useQuery({
+  queryKey: ["nakamotoBonusCoefficient"],
+  queryFn: () => nakamotoBonusCoefficientFetcher(),
+  placeholderData: keepPreviousData
+});
+const { data: annualProvisionsData } = useQuery({
+  queryKey: ["annualProvisions"],
+  queryFn: () => annualProvisionsFetcher(),
+  placeholderData: keepPreviousData
+});
+const { data: distributionParamsData } = useQuery({
+  queryKey: ["distributionParams"],
+  queryFn: () => distributionParamsFetcher(),
+  placeholderData: keepPreviousData
+});
+
+/*
+ * The bonus coefficient (η) is a LegacyDec serialized as a string (e.g.
+ * "0.030000000000000000") representing the share of rewards distributed equally.
+ * We surface it as a percentage to match the explanatory text. It is undefined
+ * on chains that don't expose the endpoint yet, in which case the box is hidden.
+ */
+const nakamotoBonusEta = computed(() => {
+  const coefficient = nakamotoBonusCoefficientData.value?.coefficient;
+  if (coefficient === undefined) {
+    return undefined;
+  }
+  return Number(coefficient);
+});
+const nakamotoBonusCoefficient = computed(() => {
+  if (nakamotoBonusEta.value === undefined) {
+    return undefined;
+  }
+  return new Intl.NumberFormat(
+    "en-US",
+    { style: "percent",
+      maximumFractionDigits: 2 }
+  ).format(nakamotoBonusEta.value);
+});
+
+/*
+ * Token total and count of the bonded validator set, shared by the Nakamoto
+ * Coefficient and the per-validator effective APR.
+ */
+const bondedStats = computed(() => {
+  const validators = data.value?.validators;
+  if (!validators) {
+    return undefined;
+  }
+  const bondedTokens = validators.
+    filter((validator: { status: string }) => validator.status === "BOND_STATUS_BONDED").
+    map((validator: { tokens: string }) => BigInt(validator.tokens));
+  if (bondedTokens.length === 0) {
+    return undefined;
+  }
+  const totalTokens = bondedTokens.reduce(
+    (sum: bigint, tokens: bigint) => sum + tokens,
+    0n
+  );
+  return { count: bondedTokens.length,
+    totalTokens,
+    sortedTokens: bondedTokens.toSorted((a: bigint, b: bigint) => {
+      if (a > b) {
+        return -1;
+      }
+      if (a < b) {
+        return 1;
+      }
+      return 0;
+    }) };
+});
+
+/*
+ * The Nakamoto Coefficient is the minimum number of validators whose combined
+ * voting power exceeds one-third of the total — the point at which they could
+ * halt consensus. It is not exposed by the chain, so we derive it from the
+ * bonded validators by accumulating tokens from largest to smallest until the
+ * running total passes one third.
+ */
+const nakamotoCoefficient = computed(() => {
+  const stats = bondedStats.value;
+  if (!stats) {
+    return undefined;
+  }
+  let cumulativeTokens = 0n;
+  let count = 0;
+  for (const tokens of stats.sortedTokens) {
+    cumulativeTokens += tokens;
+    count++;
+    if (cumulativeTokens * 3n > stats.totalTokens) {
+      break;
+    }
+  }
+  return count;
+});
+
+/*
+ * Baseline network staking APR, before the Nakamoto Bonus redistribution:
+ *   APR_base = annual_provisions * (1 - community_tax) / bonded_tokens
+ * Returned together with the bonus coefficient (η) and the average bonded stake
+ * so the per-validator effective APR can be derived without refetching.
+ */
+const aprInputs = computed(() => {
+  const annualProvisions = annualProvisionsData.value?.annual_provisions;
+  const communityTax = distributionParamsData.value?.params?.community_tax;
+  const eta = nakamotoBonusEta.value;
+  const stats = bondedStats.value;
+  if (annualProvisions === undefined || communityTax === undefined || eta === undefined || !stats) {
+    return undefined;
+  }
+  const bondedTokens = Number(stats.totalTokens);
+  if (bondedTokens === 0) {
+    return undefined;
+  }
+  const rewardPool = Number(annualProvisions) * (1 - Number(communityTax));
+  return { baseApr: rewardPool / bondedTokens,
+    eta,
+    averageStake: bondedTokens / stats.count };
+});
+
+/*
+ * Effective APR for delegating to a given validator, net of its commission.
+ * The Nakamoto Bonus splits rewards into a proportional share (1 - η) and an
+ * equal-per-validator share (η), so smaller validators earn a higher APR:
+ *   APR_i = APR_base * [(1 - η) + η * (avg_stake / validator_stake)]
+ * Only bonded validators earn staking rewards, so others return undefined.
+ */
+const getEffectiveApr = (validator: {
+  status: string;
+  tokens: string;
+  commission?: { commission_rates?: { rate?: string } };
+}) => {
+  const inputs = aprInputs.value;
+  if (!inputs || validator.status !== "BOND_STATUS_BONDED") {
+    return undefined;
+  }
+  const stake = Number(validator.tokens);
+  if (stake === 0) {
+    return undefined;
+  }
+  const grossApr = inputs.baseApr * (1 - inputs.eta + inputs.eta * inputs.averageStake / stake);
+  const commission = Number(validator.commission?.commission_rates?.rate ?? 0);
+  return new Intl.NumberFormat(
+    "en-US",
+    { style: "percent",
+      maximumFractionDigits: 2 }
+  ).format(grossApr * (1 - commission));
+};
 
 const orderedValidators = computed(() => {
   if (!data) {
@@ -90,6 +241,9 @@ setInterval(
     queryClient.invalidateQueries({ queryKey: ["rewards"] });
     queryClient.invalidateQueries({ queryKey: ["delegations"] });
     queryClient.invalidateQueries({ queryKey: ["validators"] });
+    queryClient.invalidateQueries({ queryKey: ["nakamotoBonusCoefficient"] });
+    queryClient.invalidateQueries({ queryKey: ["annualProvisions"] });
+    queryClient.invalidateQueries({ queryKey: ["distributionParams"] });
   },
   30000
 );
@@ -159,6 +313,35 @@ const getDisplayReward = (validator: string) => {
     <div v-if="userRewards.length > 0">
       <Claim :validator-address="userRewards.map((x) => x.validator_address)" />
     </div>
+    <!-- Network Decentralization -->
+    <div class="flex flex-col bg-grey-400 rounded-md p-4 gap-4">
+      <!-- Nakamoto Coefficient -->
+      <div class="flex flex-col gap-2">
+        <div class="flex flex-row justify-between items-center gap-4 flex-wrap">
+          <span class="text-grey-50 text-200 font-bold">Nakamoto Coefficient</span>
+          <span class="text-light text-400">{{ nakamotoCoefficient ?? "—" }}</span>
+        </div>
+        <p class="text-grey-100 text-100">
+          The minimum number of validators whose combined voting power exceeds one third of the total —
+          the number that would need to collude to halt consensus. A higher value means the network is
+          more decentralized.
+        </p>
+      </div>
+      <!-- Nakamoto Bonus Coefficient -->
+      <div v-if="nakamotoBonusCoefficient" class="flex flex-col gap-2 border-t pt-4 border-grey-200">
+        <div class="flex flex-row justify-between items-center gap-4 flex-wrap">
+          <span class="text-grey-50 text-200 font-bold">Nakamoto Bonus Coefficient</span>
+          <span class="text-light text-400">{{ nakamotoBonusCoefficient }}</span>
+        </div>
+        <p class="text-grey-100 text-100">
+          The share of staking rewards (η) distributed equally across all validators instead of
+          proportionally to stake. This raises the reward-per-stake of smaller validators, giving
+          delegators an incentive to support them and improve the Nakamoto Coefficient above. It adjusts
+          weekly, ranging between 3% and 100%. Each validator's resulting effective APR — net of its
+          commission — is shown below.
+        </p>
+      </div>
+    </div>
     <div v-if="data">
       <div v-for="(validator, index) in orderedValidators" :key="index" class="flex flex-col">
         <div class="flex flex-col bg-grey-400 rounded-md mb-4 p-4 flex-wrap gap-4">
@@ -188,6 +371,14 @@ const getDisplayReward = (validator: string) => {
                 :denom="chainConfig.stakeCurrency.coinDenom"
                 class="text-grey-100 text-100"
               />
+            </div>
+            <!-- Effective APR (incl. Nakamoto Bonus, net of commission) -->
+            <div
+              v-if="getEffectiveApr(validator)"
+              class="flex flex-col gap-2 items-start md:items-end"
+            >
+              <span class="text-grey-50 text-100 text-left md:text-right">Effective APR</span>
+              <span class="text-gradient text-100 font-bold">{{ getEffectiveApr(validator) }}</span>
             </div>
             <div
               v-if="

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,4 +12,7 @@ declare global {
     leap: Keplr;
     cosmostation: unknown;
   }
+  interface ImportMetaEnv {
+    readonly VITE_CHAIN_ENV?: "mainnet" | "testnet";
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,43 @@ import { fileURLToPath, URL } from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
-import { defineConfig } from "vite";
+import { defineConfig, Plugin } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import vueDevTools from "vite-plugin-vue-devtools";
+
+/*
+ * Emits a Netlify "_headers" file with a Content-Security-Policy whose
+ * connect-src is scoped to the chain this build targets. netlify.toml headers
+ * cannot vary per deploy context, so the CSP lives here instead: production
+ * (mainnet) only ever permits the mainnet endpoints, and testnet previews only
+ * the testnet endpoints. VITE_CHAIN_ENV is set per context in netlify.toml.
+ */
+const netlifyCspHeaders = (): Plugin => {
+  const mainnet = "https://atomone-rpc.allinbits.com https://atomone-api.allinbits.com";
+  const testnet = "https://atomone-testnet-1-rpc.allinbits.services https://atomone-testnet-1-api.allinbits.services";
+  return {
+    name: "netlify-csp-headers",
+    apply: "build",
+    generateBundle () {
+      const connectSrc = process.env.VITE_CHAIN_ENV === "testnet"
+        ? testnet
+        : mainnet;
+      const csp = [
+        "default-src 'self' 'wasm-unsafe-eval'",
+        "style-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'wasm-unsafe-eval'",
+        "object-src 'none'",
+        "img-src 'self' data: https:",
+        `connect-src ${connectSrc}`
+      ].join("; ");
+      this.emitFile({
+        type: "asset",
+        fileName: "_headers",
+        source: `/*\n  Content-Security-Policy: ${csp}\n`
+      });
+    }
+  };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -19,7 +53,8 @@ export default defineConfig({
     }),
     tailwindcss(),
     vue(),
-    vueDevTools()
+    vueDevTools(),
+    netlifyCspHeaders()
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
- Display the Nakamoto Coefficient (minimum validators to halt consensus) with explanatory text, preceding the Nakamoto Bonus Coefficient
- Show the bonus coefficient as a percentage instead of a decimal
- Compute and show each bonded validator's effective APR including the current Nakamoto Bonus, net of commission
- Select mainnet/testnet chain config at build time via VITE_CHAIN_ENV so Netlify deploy previews target testnet and production targets mainnet
- Emit a deploy-context-scoped CSP _headers file from the Vite build, keeping production's connect-src restricted to mainnet endpoints